### PR TITLE
Add ID and Active to rule query

### DIFF
--- a/fishbowl/api.py
+++ b/fishbowl/api.py
@@ -16,7 +16,7 @@ from . import xmlrequests, statuscodes, objects
 logger = logging.getLogger(__name__)
 
 PRICING_RULES_SQL = (
-    'SELECT product.num, '
+    'SELECT p.id, p.isactive, product.num, '
     'p.patypeid, p.papercent, p.pabaseamounttypeid, p.paamount, '
     'p.customerincltypeid, p.customerinclid '
     'from pricingrule p inner join product on p.productinclid = product.id '


### PR DESCRIPTION
I am doing a pricing rules sync in SK for so it can go to the offline client. However, it needs to be a "real" sync. In order to do that need the id to keep as a record. Also need name for the eventuality that we want to run a report of what rules were applied to what tickets, for sure.

That is the impetus behind this change. It shouldn't hurt the existing sync. However, it will probably affect the merging of quoting app and sk since the pricing rules will be in sk already.
